### PR TITLE
Renamed vrep(A, b) to setHrep(A, b) — and same for hrep(A, b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,34 @@
-# DEPRECATED
-
-Please refer to [eigen-ccd](https://github.com/vsamy/eigen-cdd)
-
 # eigen-cddlib
 
-eigen-cddlib is a library that wraps cdd library.
+Eigen wrapper for Komei Fukuda's [cdd](https://www.inf.ethz.ch/personal/fukudak/cdd_home/) library.
 
 ## Installing
 
-### Manual
-
-#### Dependencies
-
-To compile you need the following tools:
-
- * [Git]()
- * [CMake]() >= 2.8
- * [pkg-config]()
- * [doxygen]()
- * [c++ compiler]() Version to compile C++0x
- * [Boost](http://www.boost.org/doc/libs/1_58_0/more/getting_started/unix-variants.html) >= 1.58 (Older version may work as well)
- * [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) >= 3.2
- * [cdd]()
-
-#### Building
-First install cddlib
+First install ``cddlib``:
 ```sh
 sudo apt-get install libcdd-dev
 ```
-
-then install the eigen-cddlib part
+Then, install ``eigen-cddlib`` following the standard CMake procedure:
 
 ```sh
 git clone --recursive https://github.com/vsamy/eigen-cddlib
 cd eigen-cddlib
-mkdir _build
-cd _build
+mkdir build
+cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFX=<your_path>
-make -j8
+make -j4
 make install
 ```
 
-If cdd has not been install in the default path, cmake may not find it (there is no pkg-config for cdd).
-Add the path as a HINTS in find_path and/or find_library.
+If cdd has not been installed in the default path, CMake may not find it. In this case, add the path as a HINTS in ``find_path`` and/or ``find_library``.
 
-#### Testing
+### Testing
 
-Test the file by simply doing a make test.
-For c++
 ```sh
-cd eigen-cddlib/_build
+cd eigen-cddlib/build
 make test
 ```
 
-#### Examples
+## Examples
 
-There is no basic examples yet. Please see test files for an overview.
-Please see the doxygen files for the documentation.
+There is no basic examples yet. Please see test files for an overview, and doxygen files for API documentation.

--- a/src/Polyhedron.cpp
+++ b/src/Polyhedron.cpp
@@ -44,14 +44,14 @@ Polyhedron::~Polyhedron()
         dd_free_global_constants();
 }
 
-void Polyhedron::vrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
+void Polyhedron::setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
 {
     std::unique_lock<std::mutex> lock(mtx);
     if (!hvrep(A, b, false))
         throw std::runtime_error("Bad conversion from hrep to vrep.");
 }
 
-void Polyhedron::hrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
+void Polyhedron::setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
 {
     std::unique_lock<std::mutex> lock(mtx);
     if (!hvrep(A, b, true))

--- a/src/Polyhedron.cpp
+++ b/src/Polyhedron.cpp
@@ -86,6 +86,16 @@ void Polyhedron::printHrep() const
     dd_WriteMatrix(stdout, mat);
 }
 
+void Polyhedron::setRays(const Eigen::MatrixXd& R)
+{
+    setVrep(R, Eigen::VectorXd::Zero(R.rows()));
+}
+
+void Polyhedron::setVertices(const Eigen::MatrixXd& V)
+{
+    setVrep(V, Eigen::VectorXd::Ones(V.rows()));
+}
+
 /**
  * Private functions
  */

--- a/src/Polyhedron.h
+++ b/src/Polyhedron.h
@@ -73,6 +73,15 @@ public:
     /* Print the V-representation of the polyhedron */
     void printVrep() const;
 
+    /* Set the polyhedron from a matrix \f$ R = [r]^T$ of stacked ray vectors.
+     * \param R Matrix of stacked rays.
+     */
+    void setRays(const Eigen::MatrixXd& R);
+    /* Set the polyhedron from a matrix \f$ V = [v]^T$ of stacked vertices.
+     * \param V Matrix of stacked vertices.
+     */
+    void setVertices(const Eigen::MatrixXd& V);
+
 private:
     bool hvrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b, bool isFromGenerators);
     void initializeMatrixPtr(Eigen::Index rows, Eigen::Index cols, bool isFromGenerators);

--- a/src/Polyhedron.h
+++ b/src/Polyhedron.h
@@ -74,11 +74,11 @@ public:
     void printVrep() const;
 
     /* Set the polyhedron from a matrix \f$ R = [r]^T$ of stacked ray vectors.
-     * \param R Matrix of stacked rays.
+     * \param R m x n matrix of stacked rays (each ray has dimension n).
      */
     void setRays(const Eigen::MatrixXd& R);
     /* Set the polyhedron from a matrix \f$ V = [v]^T$ of stacked vertices.
-     * \param V Matrix of stacked vertices.
+     * \param V m x n matrix of stacked vertices (each vertex has dimension n).
      */
     void setVertices(const Eigen::MatrixXd& V);
 

--- a/src/Polyhedron.h
+++ b/src/Polyhedron.h
@@ -27,6 +27,9 @@
 
 namespace Eigen {
 
+  using HrepXd = std::pair<Eigen::MatrixXd, Eigen::VectorXd>;
+  using VrepXd = std::pair<Eigen::MatrixXd, Eigen::VectorXd>;
+
 /* Wrapper of Convex Polyhedron
  * This class aims to translate eigen matrix into cddlib matrix.
  * It automatically transforms a v-polyhedron into an h-polyhedron and vice-versa.
@@ -43,27 +46,27 @@ public:
      * \param A The matrix part of the representation of the polyhedron.
      * \param b The vector part of the representation of the polyhedron.
      */
-    void vrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
-    /* Treat the inputs as a V-representation and compute its H-representation
+    void setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
+    /* Treat the inputs as a V-representation and compute its H-representation.
      * V-polyhedron is such that \f$ A = [v r]^T, b=[1^T 0^T]^T \f$
      * with A composed of \f$ v \f$, the vertices, \f$ r \f$, the rays
      * and b is a vector which is 1 for vertices and 0 for rays.
      * \param A The matrix part of the representation of the polyhedron.
      * \param b The vector part of the representation of the polyhedron.
      */
-    void hrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
-    /* Get the V-representation of the polyhedron
-     * V-polyhedron is such that \f$ A = [v^T r^T]^T, b=[1^T 0^T]^T \f$
-     * with A composed of \f$ v \f$, the vertices, \f$ r \f$, the rays
-     * and b is a vector which is 1 for vertices and 0 for rays.
-     * \return Pair of vertices and rays matrix and identification vector of vertices and rays for the V-representation
+    void setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
+    /* Get the V-representation of the polyhedron.
+     * V-polyhedron is such that \f$ A = [v r]^T, b=[1^T 0^T]^T \f$
+     * with A composed of \f$ v \f$, the vertices, \f$ r \f$, the rays,
+     * and b is a corresponding vector with 1 for vertices and 0 for rays.
+     * \return Pair of vertex-ray matrix and vector of the V-representation.
      */
-    std::pair<Eigen::MatrixXd, Eigen::VectorXd> vrep() const;
-    /* Get the H-representation of the polyhedron
+    VrepXd vrep() const;
+    /* Get the H-representation of the polyhedron.
      * H-polyhedron is such that \f$ Ax \leq b \f$.
      * \return Pair of inequality matrix and inequality vector for the H-representation
      */
-    std::pair<Eigen::MatrixXd, Eigen::VectorXd> hrep() const;
+    HrepXd hrep() const;
 
     /* Print the H-representation of the polyhedron */
     void printHrep() const;

--- a/src/Polyhedron.h
+++ b/src/Polyhedron.h
@@ -41,18 +41,18 @@ public:
     /* Free the pointers and unset the cdd global constants. */
     ~Polyhedron();
 
-    /* Treat the inputs as a H-representation and compute its V-representation.
-     * H-polyhedron is such that \f$ Ax \leq b \f$.
-     * \param A The matrix part of the representation of the polyhedron.
-     * \param b The vector part of the representation of the polyhedron.
+    /* Treat the inputs as an H-representation and compute its V-representation.
+     * An H-polyhedron is such that \f$ Ax \leq b \f$.
+     * \param A Matrix part of the H-representation.
+     * \param b Vector part of the H-representation.
      */
     void setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
     /* Treat the inputs as a V-representation and compute its H-representation.
      * V-polyhedron is such that \f$ A = [v r]^T, b=[1^T 0^T]^T \f$
-     * with A composed of \f$ v \f$, the vertices, \f$ r \f$, the rays
-     * and b is a vector which is 1 for vertices and 0 for rays.
-     * \param A The matrix part of the representation of the polyhedron.
-     * \param b The vector part of the representation of the polyhedron.
+     * with A composed of \f$ v \f$, the vertices, \f$ r \f$, the rays,
+     * and b is a corresponding vector with 1 for vertices and 0 for rays.
+     * \param A Matrix part of the V-representation.
+     * \param b Vector part of the V-representation.
      */
     void setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
     /* Get the V-representation of the polyhedron.
@@ -64,7 +64,7 @@ public:
     VrepXd vrep() const;
     /* Get the H-representation of the polyhedron.
      * H-polyhedron is such that \f$ Ax \leq b \f$.
-     * \return Pair of inequality matrix and inequality vector for the H-representation
+     * \return Pair of inequality matrix and inequality vector of the H-representation.
      */
     HrepXd hrep() const;
 

--- a/tests/TestPolyhedron.cpp
+++ b/tests/TestPolyhedron.cpp
@@ -27,35 +27,52 @@
 
 struct Rep {
     Rep()
-        : AVrep(4, 3)
-        , AHrep(4, 3)
-        , bVrep(4)
-        , bHrep(4)
+        : AVrepCone(4, 3)
+        , AHrepCone(4, 3)
+        , bVrepCone(4)
+        , bHrepCone(4)
+        , AVrepSquare(4, 2)
+        , AHrepSquare(4, 2)
+        , bVrepSquare(4)
+        , bHrepSquare(4)
     {
-        AVrep << 1, 1, 2,
+        AVrepCone << 1, 1, 2,
             1, -1, 2,
             -1, -1, 2,
-            -1, 1, 2; // Friction cone inequality * 2
-        AHrep << -2, 0, -1,
+            -1, 1, 2;
+        AHrepCone << -2, 0, -1,
             0, -2, -1,
             2, 0, -1,
             0, 2, -1;
-        bVrep << 0, 0, 0, 0;
-        bHrep << 0, 0, 0, 0;
+        bVrepCone << 0, 0, 0, 0;
+        bHrepCone << 0, 0, 0, 0;
+        AVrepSquare << 1, 1,
+            1, -1,
+            -1, -1,
+            -1, 1;
+        AHrepSquare << 0, -1,
+            -1, 0,
+            0, 1,
+            1, 0;
+        bVrepSquare << 1, 1, 1, 1;
+        bHrepSquare << 1, 1, 1, 1;
     }
 
-    Eigen::MatrixXd AVrep, AHrep;
-    Eigen::VectorXd bVrep, bHrep;
+    Eigen::MatrixXd AVrepCone, AHrepCone;
+    Eigen::VectorXd bVrepCone, bHrepCone;
+
+    Eigen::MatrixXd AVrepSquare, AHrepSquare;
+    Eigen::VectorXd bVrepSquare, bHrepSquare;
 };
 
 BOOST_FIXTURE_TEST_CASE(Vrep2Hrep, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.setVrep(AVrep, bVrep);
+    poly.setVrep(AVrepCone, bVrepCone);
     auto hrep = poly.hrep();
-    BOOST_CHECK(AHrep.isApprox(hrep.first));
-    BOOST_CHECK(bHrep.isApprox(hrep.second));
+    BOOST_CHECK(AHrepCone.isApprox(hrep.first));
+    BOOST_CHECK(bHrepCone.isApprox(hrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
     std::cout << "Wall time: " << std::chrono::duration<double, std::milli>(t_end - t_start).count() << "ms" << std::endl;
 
@@ -66,12 +83,40 @@ BOOST_FIXTURE_TEST_CASE(Hrep2Vrep, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.setHrep(AHrep, bHrep);
+    poly.setHrep(AHrepCone, bHrepCone);
     auto vrep = poly.vrep();
-    BOOST_CHECK(AVrep.isApprox(vrep.first));
-    BOOST_CHECK(bVrep.isApprox(vrep.second));
+    BOOST_CHECK(AVrepCone.isApprox(vrep.first));
+    BOOST_CHECK(bVrepCone.isApprox(vrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
     std::cout << "Wall time: " << std::chrono::duration<double, std::milli>(t_end - t_start).count() << "ms" << std::endl;
 
     poly.printVrep();
+}
+
+BOOST_FIXTURE_TEST_CASE(setRays, Rep)
+{
+    auto t_start = std::chrono::high_resolution_clock::now();
+    Eigen::Polyhedron poly;
+    poly.setRays(AVrepCone);
+    auto hrep = poly.hrep();
+    BOOST_CHECK(AHrepCone.isApprox(hrep.first));
+    BOOST_CHECK(bHrepCone.isApprox(hrep.second));
+    auto t_end = std::chrono::high_resolution_clock::now();
+    std::cout << "Wall time: " << std::chrono::duration<double, std::milli>(t_end - t_start).count() << "ms" << std::endl;
+
+    poly.printHrep();
+}
+
+BOOST_FIXTURE_TEST_CASE(setVertices, Rep)
+{
+    auto t_start = std::chrono::high_resolution_clock::now();
+    Eigen::Polyhedron poly;
+    poly.setVertices(AVrepSquare);
+    auto hrep = poly.hrep();
+    BOOST_CHECK(AHrepSquare.isApprox(hrep.first));
+    BOOST_CHECK(bHrepSquare.isApprox(hrep.second));
+    auto t_end = std::chrono::high_resolution_clock::now();
+    std::cout << "Wall time: " << std::chrono::duration<double, std::milli>(t_end - t_start).count() << "ms" << std::endl;
+
+    poly.printHrep();
 }

--- a/tests/TestPolyhedron.cpp
+++ b/tests/TestPolyhedron.cpp
@@ -52,7 +52,7 @@ BOOST_FIXTURE_TEST_CASE(Vrep2Hrep, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.hrep(AVrep, bVrep);
+    poly.setVrep(AVrep, bVrep);
     auto hrep = poly.hrep();
     BOOST_CHECK(AHrep.isApprox(hrep.first));
     BOOST_CHECK(bHrep.isApprox(hrep.second));
@@ -66,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE(Hrep2Vrep, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.vrep(AHrep, bHrep);
+    poly.setHrep(AHrep, bHrep);
     auto vrep = poly.vrep();
     BOOST_CHECK(AVrep.isApprox(vrep.first));
     BOOST_CHECK(bVrep.isApprox(vrep.second));


### PR DESCRIPTION
I was confused by ``poly.vrep(A, b)``:
- Expected: set the V-rep (A, b)
- Implemented: set an *H*-rep (A, b) and *then* compute the V-rep

To avoid this confusion, I think explicit doesn't hurt:
```cpp
poly.setHrep(A, b)  // (A, b) is an H-rep, computes the V-rep
poly.setVrep(A, b)  // (A, b) is  a V-rep, computes the H-rep
```
This is the main change in this PR. The rest are cosmetics: feel free to filter them as you like.