### PR TITLE
Error handling and dd_NumericallyInconsistent test

### DIFF
--- a/src/Polyhedron.cpp
+++ b/src/Polyhedron.cpp
@@ -17,6 +17,8 @@
 
 #include "Polyhedron.h"
 
+#include <fstream>
+
 namespace Eigen {
 
 std::atomic_int Polyhedron::counter(0);
@@ -153,49 +155,20 @@ std::pair<Eigen::MatrixXd, Eigen::VectorXd> Polyhedron::ddfMatrix2EigenMatrix(co
     return std::make_pair(mOut, vOut);
 }
 
-std::string Polyhedron::stringFromError(dd_ErrorType err)
+std::string Polyhedron::lastErrorMessage()
 {
-  switch (err)
-  {
-    case dd_CannotHandleLinearity:
-      return "dd_CannotHandleLinearity";
-    case dd_ColIndexOutOfRange:
-      return "dd_ColIndexOutOfRange";
-    case dd_DimensionTooLarge:
-      return "dd_DimensionTooLarge";
-    case dd_EmptyHrepresentation:
-      return "dd_EmptyHrepresentation";
-    case dd_EmptyRepresentation:
-      return "dd_EmptyRepresentation";
-    case dd_EmptyVrepresentation:
-      return "dd_EmptyVrepresentation";
-    case dd_IFileNotFound:
-      return "dd_IFileNotFound";
-    case dd_ImproperInputFormat:
-      return "dd_ImproperInputFormat";
-    case dd_LPCycling:
-      return "dd_LPCycling";
-    case dd_NegativeMatrixSize:
-      return "dd_NegativeMatrixSize";
-    case dd_NoError:
-      return "dd_NoError";
-    case dd_NoLPObjective:
-      return "dd_NoLPObjective";
-    case dd_NoRealNumberSupport:
-      return "dd_NoRealNumberSupport";
-    case dd_NotAvailForH:
-      return "dd_NotAvailForH";
-    case dd_NotAvailForV:
-      return "dd_NotAvailForV";
-    case dd_NumericallyInconsistent:
-      return "dd_NumericallyInconsistent";
-    case dd_OFileNotOpen:
-      return "dd_OFileNotOpen";
-    case dd_RowIndexOutOfRange:
-      return "dd_RowIndexOutOfRange";
-    default:
-      return "undefined error";
-  }
+    constexpr char TMP_FPATH[] = "/tmp/dd_lastErrorMessage";
+    FILE * tmpFile = fopen(TMP_FPATH, "w");
+    if (!tmpFile)
+    {
+        return "Cannot get last error message: unable to write temporary file in /tmp";
+    }
+    dd_WriteErrorMessages(tmpFile, err_);
+    fclose(tmpFile);
+    std::ifstream fileStream(TMP_FPATH);
+    std::stringstream buffer;
+    buffer << fileStream.rdbuf();
+    return buffer.str();
 }
 
 } // namespace Eigen

--- a/src/Polyhedron.cpp
+++ b/src/Polyhedron.cpp
@@ -44,18 +44,16 @@ Polyhedron::~Polyhedron()
         dd_free_global_constants();
 }
 
-void Polyhedron::setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
+bool Polyhedron::setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
 {
     std::unique_lock<std::mutex> lock(mtx);
-    if (!hvrep(A, b, false))
-        throw std::runtime_error("H-rep to V-rep conversion failed: " + stringFromError(err_));
+    return hvrep(A, b, false);
 }
 
-void Polyhedron::setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
+bool Polyhedron::setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
 {
     std::unique_lock<std::mutex> lock(mtx);
-    if (!hvrep(A, b, true))
-        throw std::runtime_error("V-rep to H-rep conversion failed: " + stringFromError(err_));
+    return hvrep(A, b, true);
 }
 
 std::pair<Eigen::MatrixXd, Eigen::VectorXd> Polyhedron::vrep() const
@@ -86,14 +84,14 @@ void Polyhedron::printHrep() const
     dd_WriteMatrix(stdout, mat);
 }
 
-void Polyhedron::setRays(const Eigen::MatrixXd& R)
+bool Polyhedron::setRays(const Eigen::MatrixXd& R)
 {
-    setVrep(R, Eigen::VectorXd::Zero(R.rows()));
+    return setVrep(R, Eigen::VectorXd::Zero(R.rows()));
 }
 
-void Polyhedron::setVertices(const Eigen::MatrixXd& V)
+bool Polyhedron::setVertices(const Eigen::MatrixXd& V)
 {
-    setVrep(V, Eigen::VectorXd::Ones(V.rows()));
+    return setVrep(V, Eigen::VectorXd::Ones(V.rows()));
 }
 
 /**

--- a/src/Polyhedron.cpp
+++ b/src/Polyhedron.cpp
@@ -48,14 +48,14 @@ void Polyhedron::setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
 {
     std::unique_lock<std::mutex> lock(mtx);
     if (!hvrep(A, b, false))
-        throw std::runtime_error("Bad conversion from hrep to vrep.");
+        throw std::runtime_error("H-rep to V-rep conversion failed: " + stringFromError(err_));
 }
 
 void Polyhedron::setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b)
 {
     std::unique_lock<std::mutex> lock(mtx);
     if (!hvrep(A, b, true))
-        throw std::runtime_error("Bad conversion from vrep to hrep.");
+        throw std::runtime_error("V-rep to H-rep conversion failed: " + stringFromError(err_));
 }
 
 std::pair<Eigen::MatrixXd, Eigen::VectorXd> Polyhedron::vrep() const
@@ -153,6 +153,51 @@ std::pair<Eigen::MatrixXd, Eigen::VectorXd> Polyhedron::ddfMatrix2EigenMatrix(co
     }
 
     return std::make_pair(mOut, vOut);
+}
+
+std::string Polyhedron::stringFromError(dd_ErrorType err)
+{
+  switch (err)
+  {
+    case dd_CannotHandleLinearity:
+      return "dd_CannotHandleLinearity";
+    case dd_ColIndexOutOfRange:
+      return "dd_ColIndexOutOfRange";
+    case dd_DimensionTooLarge:
+      return "dd_DimensionTooLarge";
+    case dd_EmptyHrepresentation:
+      return "dd_EmptyHrepresentation";
+    case dd_EmptyRepresentation:
+      return "dd_EmptyRepresentation";
+    case dd_EmptyVrepresentation:
+      return "dd_EmptyVrepresentation";
+    case dd_IFileNotFound:
+      return "dd_IFileNotFound";
+    case dd_ImproperInputFormat:
+      return "dd_ImproperInputFormat";
+    case dd_LPCycling:
+      return "dd_LPCycling";
+    case dd_NegativeMatrixSize:
+      return "dd_NegativeMatrixSize";
+    case dd_NoError:
+      return "dd_NoError";
+    case dd_NoLPObjective:
+      return "dd_NoLPObjective";
+    case dd_NoRealNumberSupport:
+      return "dd_NoRealNumberSupport";
+    case dd_NotAvailForH:
+      return "dd_NotAvailForH";
+    case dd_NotAvailForV:
+      return "dd_NotAvailForV";
+    case dd_NumericallyInconsistent:
+      return "dd_NumericallyInconsistent";
+    case dd_OFileNotOpen:
+      return "dd_OFileNotOpen";
+    case dd_RowIndexOutOfRange:
+      return "dd_RowIndexOutOfRange";
+    default:
+      return "undefined error";
+  }
 }
 
 } // namespace Eigen

--- a/src/Polyhedron.h
+++ b/src/Polyhedron.h
@@ -88,6 +88,7 @@ private:
     bool doubleDescription(const Eigen::MatrixXd& matrix, bool isFromGenerators);
     Eigen::MatrixXd concatenateMatrix(const Eigen::MatrixXd& A, const Eigen::VectorXd& b, bool isFromGenerators);
     std::pair<Eigen::MatrixXd, Eigen::VectorXd> ddfMatrix2EigenMatrix(const dd_MatrixPtr mat, bool isOuputVRep) const;
+    std::string stringFromError(dd_ErrorType err);
 
 private:
     dd_MatrixPtr matPtr_;

--- a/src/Polyhedron.h
+++ b/src/Polyhedron.h
@@ -45,16 +45,18 @@ public:
      * An H-polyhedron is such that \f$ Ax \leq b \f$.
      * \param A Matrix part of the H-representation.
      * \param b Vector part of the H-representation.
+     * \return true if the conversion was successful.
      */
-    void setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
+    bool setHrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
     /* Treat the inputs as a V-representation and compute its H-representation.
      * V-polyhedron is such that \f$ A = [v r]^T, b=[1^T 0^T]^T \f$
      * with A composed of \f$ v \f$, the vertices, \f$ r \f$, the rays,
      * and b is a corresponding vector with 1 for vertices and 0 for rays.
      * \param A Matrix part of the V-representation.
      * \param b Vector part of the V-representation.
+     * \return true if the conversion was successful.
      */
-    void setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
+    bool setVrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
     /* Get the V-representation of the polyhedron.
      * V-polyhedron is such that \f$ A = [v r]^T, b=[1^T 0^T]^T \f$
      * with A composed of \f$ v \f$, the vertices, \f$ r \f$, the rays,
@@ -75,12 +77,14 @@ public:
 
     /* Set the polyhedron from a matrix \f$ R = [r]^T$ of stacked ray vectors.
      * \param R m x n matrix of stacked rays (each ray has dimension n).
+     * \return true if the conversion was successful.
      */
-    void setRays(const Eigen::MatrixXd& R);
+    bool setRays(const Eigen::MatrixXd& R);
     /* Set the polyhedron from a matrix \f$ V = [v]^T$ of stacked vertices.
      * \param V m x n matrix of stacked vertices (each vertex has dimension n).
+     * \return true if the conversion was successful.
      */
-    void setVertices(const Eigen::MatrixXd& V);
+    bool setVertices(const Eigen::MatrixXd& V);
 
 private:
     bool hvrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b, bool isFromGenerators);

--- a/src/Polyhedron.h
+++ b/src/Polyhedron.h
@@ -85,6 +85,10 @@ public:
      * \return true if the conversion was successful.
      */
     bool setVertices(const Eigen::MatrixXd& V);
+    /* Get a readable error message for the last conversion error.
+     * \return String for last error message.
+     */
+    std::string lastErrorMessage();
 
 private:
     bool hvrep(const Eigen::MatrixXd& A, const Eigen::VectorXd& b, bool isFromGenerators);
@@ -92,7 +96,6 @@ private:
     bool doubleDescription(const Eigen::MatrixXd& matrix, bool isFromGenerators);
     Eigen::MatrixXd concatenateMatrix(const Eigen::MatrixXd& A, const Eigen::VectorXd& b, bool isFromGenerators);
     std::pair<Eigen::MatrixXd, Eigen::VectorXd> ddfMatrix2EigenMatrix(const dd_MatrixPtr mat, bool isOuputVRep) const;
-    std::string stringFromError(dd_ErrorType err);
 
 private:
     dd_MatrixPtr matPtr_;

--- a/tests/TestPolyhedron.cpp
+++ b/tests/TestPolyhedron.cpp
@@ -120,3 +120,22 @@ BOOST_FIXTURE_TEST_CASE(setVertices, Rep)
 
     poly.printHrep();
 }
+
+BOOST_FIXTURE_TEST_CASE(setVertices2D, Rep)
+{
+    auto t_start = std::chrono::high_resolution_clock::now();
+    Eigen::MatrixXd vertices{8, 2};
+    vertices <<
+      1.07251350992533,   0.175746163122458,
+      1.07251350992533,   0.0457461631224578,
+      0.848513509925328,  0.0457461631224578,
+      0.848513509925328,  0.175746163122458,
+      1.07251394042948,  -0.0443321701680914,
+      1.07251394042948,  -0.174332170168091,
+      0.848513940429476, -0.174332170168091,
+      0.848513940429476, -0.0443321701680914;
+    Eigen::Polyhedron poly;
+    BOOST_REQUIRE_THROW(poly.setVertices(vertices), std::runtime_error);
+    auto t_end = std::chrono::high_resolution_clock::now();
+    std::cout << "Wall time: " << std::chrono::duration<double, std::milli>(t_end - t_start).count() << "ms" << std::endl;
+}

--- a/tests/TestPolyhedron.cpp
+++ b/tests/TestPolyhedron.cpp
@@ -98,8 +98,9 @@ BOOST_FIXTURE_TEST_CASE(Vrep2Hrep, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.setVrep(AVrepCone, bVrepCone);
+    bool success = poly.setVrep(AVrepCone, bVrepCone);
     auto hrep = poly.hrep();
+    BOOST_CHECK(success);
     BOOST_CHECK(AHrepCone.isApprox(hrep.first));
     BOOST_CHECK(bHrepCone.isApprox(hrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -112,8 +113,9 @@ BOOST_FIXTURE_TEST_CASE(Hrep2Vrep, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.setHrep(AHrepCone, bHrepCone);
+    bool success = poly.setHrep(AHrepCone, bHrepCone);
     auto vrep = poly.vrep();
+    BOOST_CHECK(success);
     BOOST_CHECK(AVrepCone.isApprox(vrep.first));
     BOOST_CHECK(bVrepCone.isApprox(vrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -126,8 +128,9 @@ BOOST_FIXTURE_TEST_CASE(setRays, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.setRays(AVrepCone);
+    bool success = poly.setRays(AVrepCone);
     auto hrep = poly.hrep();
+    BOOST_CHECK(success);
     BOOST_CHECK(AHrepCone.isApprox(hrep.first));
     BOOST_CHECK(bHrepCone.isApprox(hrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -140,8 +143,9 @@ BOOST_FIXTURE_TEST_CASE(setVertices, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.setVertices(AVrepSquare);
+    bool success = poly.setVertices(AVrepSquare);
     auto hrep = poly.hrep();
+    BOOST_CHECK(success);
     BOOST_CHECK(AHrepSquare.isApprox(hrep.first));
     BOOST_CHECK(bHrepSquare.isApprox(hrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -154,8 +158,9 @@ BOOST_FIXTURE_TEST_CASE(setVertices2D, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
     Eigen::Polyhedron poly;
-    poly.setVertices(vertices2D);
+    bool success = poly.setVertices(vertices2D);
     auto hrep = poly.hrep();
+    BOOST_CHECK(success);
     BOOST_CHECK(AHrepVertices2D.isApprox(hrep.first, 1e-5));
     BOOST_CHECK(bHrepVertices2D.isApprox(hrep.second, 1e-5));
     auto t_end = std::chrono::high_resolution_clock::now();

--- a/tests/TestPolyhedron.cpp
+++ b/tests/TestPolyhedron.cpp
@@ -35,6 +35,9 @@ struct Rep {
         , AHrepSquare(4, 2)
         , bVrepSquare(4)
         , bHrepSquare(4)
+        , vertices2D(8, 2)
+        , AHrepVertices2D(6, 2)
+        , bHrepVertices2D(6)
     {
         AVrepCone << 1, 1, 2,
             1, -1, 2,
@@ -56,6 +59,29 @@ struct Rep {
             1, 0;
         bVrepSquare << 1, 1, 1, 1;
         bHrepSquare << 1, 1, 1, 1;
+        vertices2D <<
+          1.23574805739044, 0.157474652673044,
+          1.23574805739044, 0.0274746526730442,
+          1.01174805739044, 0.0274746526730442,
+          1.01174805739044, 0.157474652673044,
+          1.23565994710417, -0.0223938092347823,
+          1.23565994710417, -0.152393809234782,
+          1.01165994710417, -0.152393809234782,
+          1.01165994710417, -0.0223938092347823;
+        AHrepVertices2D <<
+          2041.40139990995, -1,
+          1.66519403934611e-12, -6.56194634821138,
+          -1, -0,
+          -2041.40140187324, 1,
+          7.27623780808067e-12, 6.35022832574365,
+          1, 4.08077501031036e-16;
+        bHrepVertices2D <<
+          2522.63033964017,
+          1,
+          -1.01165994710417,
+          -2065.22642804669,
+          1,
+          1.23574805739044;
     }
 
     Eigen::MatrixXd AVrepCone, AHrepCone;
@@ -63,6 +89,9 @@ struct Rep {
 
     Eigen::MatrixXd AVrepSquare, AHrepSquare;
     Eigen::VectorXd bVrepSquare, bHrepSquare;
+
+    Eigen::MatrixXd vertices2D, AHrepVertices2D;
+    Eigen::VectorXd bHrepVertices2D;
 };
 
 BOOST_FIXTURE_TEST_CASE(Vrep2Hrep, Rep)
@@ -124,18 +153,15 @@ BOOST_FIXTURE_TEST_CASE(setVertices, Rep)
 BOOST_FIXTURE_TEST_CASE(setVertices2D, Rep)
 {
     auto t_start = std::chrono::high_resolution_clock::now();
-    Eigen::MatrixXd vertices{8, 2};
-    vertices <<
-      1.07251350992533,   0.175746163122458,
-      1.07251350992533,   0.0457461631224578,
-      0.848513509925328,  0.0457461631224578,
-      0.848513509925328,  0.175746163122458,
-      1.07251394042948,  -0.0443321701680914,
-      1.07251394042948,  -0.174332170168091,
-      0.848513940429476, -0.174332170168091,
-      0.848513940429476, -0.0443321701680914;
     Eigen::Polyhedron poly;
-    BOOST_REQUIRE_THROW(poly.setVertices(vertices), std::runtime_error);
+    poly.setVertices(vertices2D);
+    auto hrep = poly.hrep();
+    BOOST_CHECK(AHrepVertices2D.isApprox(hrep.first, 1e-5));
+    BOOST_CHECK(bHrepVertices2D.isApprox(hrep.second, 1e-5));
     auto t_end = std::chrono::high_resolution_clock::now();
     std::cout << "Wall time: " << std::chrono::duration<double, std::milli>(t_end - t_start).count() << "ms" << std::endl;
+
+    std::cout << (AHrepVertices2D - hrep.first).norm() << std::endl;
+    std::cout << (bHrepVertices2D - hrep.second).norm() << std::endl;
+    poly.printHrep();
 }

--- a/tests/TestPolyhedron.cpp
+++ b/tests/TestPolyhedron.cpp
@@ -22,8 +22,13 @@
 #include <chrono>
 #include <iostream>
 #include <utility>
+#include <string>
 
 #include "Polyhedron.h"
+
+namespace {
+    constexpr char DD_NO_ERROR_STRING[] = "*No Error found.\n";
+}
 
 struct Rep {
     Rep()
@@ -101,6 +106,7 @@ BOOST_FIXTURE_TEST_CASE(Vrep2Hrep, Rep)
     bool success = poly.setVrep(AVrepCone, bVrepCone);
     auto hrep = poly.hrep();
     BOOST_CHECK(success);
+    BOOST_CHECK(poly.lastErrorMessage() == DD_NO_ERROR_STRING);
     BOOST_CHECK(AHrepCone.isApprox(hrep.first));
     BOOST_CHECK(bHrepCone.isApprox(hrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -116,6 +122,7 @@ BOOST_FIXTURE_TEST_CASE(Hrep2Vrep, Rep)
     bool success = poly.setHrep(AHrepCone, bHrepCone);
     auto vrep = poly.vrep();
     BOOST_CHECK(success);
+    BOOST_CHECK(poly.lastErrorMessage() == DD_NO_ERROR_STRING);
     BOOST_CHECK(AVrepCone.isApprox(vrep.first));
     BOOST_CHECK(bVrepCone.isApprox(vrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -131,6 +138,7 @@ BOOST_FIXTURE_TEST_CASE(setRays, Rep)
     bool success = poly.setRays(AVrepCone);
     auto hrep = poly.hrep();
     BOOST_CHECK(success);
+    BOOST_CHECK(poly.lastErrorMessage() == DD_NO_ERROR_STRING);
     BOOST_CHECK(AHrepCone.isApprox(hrep.first));
     BOOST_CHECK(bHrepCone.isApprox(hrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -146,6 +154,7 @@ BOOST_FIXTURE_TEST_CASE(setVertices, Rep)
     bool success = poly.setVertices(AVrepSquare);
     auto hrep = poly.hrep();
     BOOST_CHECK(success);
+    BOOST_CHECK(poly.lastErrorMessage() == DD_NO_ERROR_STRING);
     BOOST_CHECK(AHrepSquare.isApprox(hrep.first));
     BOOST_CHECK(bHrepSquare.isApprox(hrep.second));
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -161,6 +170,7 @@ BOOST_FIXTURE_TEST_CASE(setVertices2D, Rep)
     bool success = poly.setVertices(vertices2D);
     auto hrep = poly.hrep();
     BOOST_CHECK(success);
+    BOOST_CHECK(poly.lastErrorMessage() == DD_NO_ERROR_STRING);
     BOOST_CHECK(AHrepVertices2D.isApprox(hrep.first, 1e-5));
     BOOST_CHECK(bHrepVertices2D.isApprox(hrep.second, 1e-5));
     auto t_end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
This tiny PR reports more details on cdd errors to the user. It also adds a test for a runtime error (dd_NumericallyInconsistent) that I encountered in practice. Please check that this test is reproducible on your machine, as its values may be specific to my architecture somehow.